### PR TITLE
Demonstrate parsing of overlapping --select and --ignore

### DIFF
--- a/testsuite/test_api.py
+++ b/testsuite/test_api.py
@@ -200,6 +200,10 @@ class APITestCase(unittest.TestCase):
         self.assertEqual(options.select, ('E',))
         self.assertEqual(options.ignore, ('E24',))
 
+        options = parse_argv('--select E,W --ignore W503').options
+        self.assertEqual(options.select, ('E', 'W'))
+        self.assertEqual(options.ignore, ('W503',))
+
         options = parse_argv('--ignore E --select E24').options
         self.assertEqual(options.select, ('E24',))
         self.assertEqual(options.ignore, ('E',))
@@ -228,6 +232,11 @@ class APITestCase(unittest.TestCase):
         self.assertFalse(pep8style.ignore_code('F'))
         self.assertFalse(pep8style.ignore_code('F401'))
         self.assertTrue(pep8style.ignore_code('F402'))
+
+        pep8style = pep8.StyleGuide(select=['W', 'E'], ignore=["W503"])
+        self.assertFalse(pep8style.ignore_code('E122'))
+        self.assertFalse(pep8style.ignore_code('W191'))
+        self.assertTrue(pep8style.ignore_code('W503'))
 
     def test_styleguide_excluded(self):
         pep8style = pep8.StyleGuide(paths=[E11])


### PR DESCRIPTION
Uses the actual example from PyCQA/pep8#390 in tests for PyCQA/pep8#433 to demonstrate the desired behaviour
